### PR TITLE
Added Latitude and Longitude format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,15 @@ impl<'a> NormalizedCityRecord<'a> {
             self.inner.location.as_ref()?.latitude?,
         ))
     }
+
+    /// Returns the [`Option<(f64, f64)>`] of record [`NormalizedCityRecord`].
+    /// Returns `None` if the latitude is not available.
+    pub fn lat_and_lon(&self) -> Option<(f64, f64)> {
+        Some((
+            self.inner.location.as_ref()?.latitude?,
+            self.inner.location.as_ref()?.longitude?,
+        ))
+    }
 }
 
 impl<'a> From<maxminddb::geoip2::City<'a>> for NormalizedCityRecord<'a> {


### PR DESCRIPTION
Google Maps and other software prefer the format of Latitude then Longitude. Added method with that format for your review. Many thanks for the library! 